### PR TITLE
Enable Excel upload on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,13 @@
         </div>
     </div>
 
+    <!-- Subir Excel con datos de productos -->
+    <input type="file" id="excelFile" accept=".xlsx, .xls" />
+    <button id="cargarExcel">Cargar datos desde Excel</button>
+
+    <!-- SheetJS para leer Excel -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <!-- Tu script principal -->
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -166,3 +166,39 @@ if (cargarExcelBtn && excelInput) {
   });
 }
 
+const input = document.getElementById('excelFile');
+const btn = document.getElementById('cargarExcel');
+const formatter = new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' });
+
+btn?.addEventListener('click', () => {
+  if (!input?.files?.length) return alert('Selecciona un archivo Excel primero');
+  const reader = new FileReader();
+  reader.onload = e => {
+    const data = new Uint8Array(e.target.result);
+    const wb = XLSX.read(data, { type: 'array' });
+    const sheet = wb.Sheets[wb.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet);
+
+    // Limpiar cada grid (veterinarios y agroquímicos)
+    document.querySelectorAll('.grid').forEach(grid => grid.innerHTML = '');
+
+    // Crear tarjetas desde el Excel
+    rows.forEach(r => {
+      const key = r.Categoría?.toLowerCase() === 'veterinarios' ? 'veterinarios' : 'agroquimicos';
+      const container = document.querySelector(`.grid.${key}`);
+      if (!container) return;
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.innerHTML = `
+        <img src="images/${r.Nombre.trim()}.jpg" alt="${r.Nombre.trim()}">
+        <h3>${r.Nombre.trim()}</h3>
+        <p>Ingrediente activo: ${r.Ingrediente}</p>
+        <p class="precio">${formatter.format(r.Precio)}</p>
+        <button class="ver-mas" data-producto="${r.Nombre.trim()}">Ver más</button>
+      `;
+      container.appendChild(card);
+    });
+  };
+  reader.readAsArrayBuffer(input.files[0]);
+});
+


### PR DESCRIPTION
## Summary
- add Excel file upload elements and script imports to `index.html`
- append Excel parsing logic to `script.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a576f8d883279d8cb4629b53dc54