### PR TITLE
Fix card image scaling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -165,10 +165,11 @@ body {
 }
 
 .card img {
-    width: 100%;
-    height: 200px;           /* ajusta la altura según el diseño */
-    object-fit: cover;       /* recorta y escala para llenar */
-    display: block;          /* elimina espacios en línea */
+    width: 100%;        /* ocupa todo el ancho de la card */
+    height: auto;       /* ajusta altura según proporción */
+    max-height: 200px;  /* opcional: límite de altura */
+    object-fit: contain; /* escala sin recortar */
+    display: block;     /* elimina espacios en línea */
 }
 
 .card h3 {


### PR DESCRIPTION
## Summary
- scale `.card img` proportionally without cropping

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848abafeff88327bf455740b2987ad3