### PR TITLE
Fix relative image paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     </header>
 
     <section id="hero" class="hero reveal">
-        <img src="images/LOGO.png" alt="Logo El Ranchero" class="hero-logo">
+        <img src="./images/LOGO.png" alt="Logo El Ranchero" class="hero-logo">
         <h1>Soluciones seguras para el campo y tus animales</h1>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,7 @@ body {
     justify-content: center;
     align-items: center;
     text-align: center;
-    background: url("images/background.PNG") center/cover no-repeat;
+    background: url("./images/background.PNG") center/cover no-repeat;
     padding: 2rem;
     margin-top: 0px;
     color: var(--white);


### PR DESCRIPTION
## Summary
- use `./images/...` for all image sources
- update CSS background URL to be relative

## Testing
- `npm start` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6848d900685c832785357748c01ef7de