### PR TITLE
Enable CORS and static host

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -172,7 +172,7 @@ if (cargarExcelBtn && inputFile) {
           imagen: row['Imagen']
         };
 
-        fetch('http://localhost:3000/api/productos', {
+        fetch('/api/productos', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)

--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,15 @@
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
-const cors = require('cors');
 const ExcelJS = require('exceljs');
-const path = require('path');
 
 const app = express();
-app.use(cors());
 app.use(express.json());
+
+const cors = require('cors');
+app.use(cors());
+
+const path = require('path');
+app.use(express.static(path.join(__dirname, '..')));
 
 // GET /api/productos
 app.get('/api/productos', (req, res) => {


### PR DESCRIPTION
## Summary
- register CORS after express.json
- serve static files from repo root
- use relative API calls in script.js

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6849ead8807c8327be8683e4899ebf98