### PR TITLE
Fix image path with imagen field

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const div = document.createElement('div');
     div.className = 'card';
     div.innerHTML = `
-      <img src="images/${p.nombre}.jpg" alt="${p.nombre}">
+      <img src="/images/${p.imagen}" alt="${p.nombre}">
       <h3>${p.nombre}</h3>
       <p>Ingrediente activo: ${p.ingrediente}</p>
       <p class="precio">Precio: ${p.precio}</p>


### PR DESCRIPTION
## Summary
- use `p.imagen` directly when building product cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a00f071648327bd52b0534f856049