### PR TITLE
Update admin page with category select and admin list

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -37,10 +37,17 @@
             <input name="nombre" placeholder="Nombre">
             <input name="ingrediente" placeholder="Ingrediente">
             <input type="number" step="0.01" name="precio" placeholder="Precio">
-            <input name="categoria" placeholder="Categoría">
+            <select name="categoria" id="categoriaSelect" required>
+              <option value="">Selecciona categoría</option>
+              <option value="veterinarios">Veterinarios</option>
+              <option value="agroquimicos">Agroquímicos</option>
+            </select>
             <input name="imagen" placeholder="Imagen">
             <button type="submit">Guardar</button>
         </form>
+
+        <h2>Productos existentes</h2>
+        <ul id="admin-lista"></ul>
     </main>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>


### PR DESCRIPTION
## Summary
- switch category input to a select menu
- add admin list container in admin page
- render admin product list and allow deletion
- refresh list after Excel import
- ensure product form uses selected category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a017116c083279c6200b373f3361e