### PR TITLE
Update admin category select

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -39,8 +39,6 @@
             <input type="number" step="0.01" name="precio" placeholder="Precio">
             <select name="categoria" id="categoriaSelect" required>
               <option value="">Selecciona categoría</option>
-              <option value="veterinarios">Veterinarios</option>
-              <option value="agroquimicos">Agroquímicos</option>
             </select>
             <input name="imagen" placeholder="Imagen">
             <button type="submit">Guardar</button>


### PR DESCRIPTION
## Summary
- drop static category options in admin form
- dynamically populate categories from API
- refresh admin table without ingredient field
- add category display on product cards
- adjust Excel import to omit ingredient column

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0a1179788327a31ba5d4c16a83eb