### PR TITLE
Add category images and nav update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,7 @@
             </button>
             <ul class="nav-menu">
                 <li><a href="#hero">Inicio</a></li>
-                <li><a href="#agroquimicos">Agroquímicos</a></li>
-                <li><a href="#veterinarios">Veterinarios</a></li>
+                <li><a href="index.html#categories-container">Categorías</a></li>
                 <li><a href="#contacto">Contacto</a></li>
             </ul>
         </nav>

--- a/public/script.js
+++ b/public/script.js
@@ -79,8 +79,36 @@ document.addEventListener('DOMContentLoaded', () => {
     'ALIMENTOS BALANCEADOS',
     'FORRAJES',
     'RATICIDA',
-    'SERVICIOS'
+  'SERVICIOS'
   ];
+
+  const categoryImages = {
+    'MEDICAMENTOS': 'medicamentos.png',
+    'GARRAPATICIDAS MOSQUICIDAS': 'garrapaticidas.png',
+    'AVES DE CORRAL': 'aves_de_corral.png',
+    'INSECTICIDAS': 'insecticidas.png',
+    'BIOLÓGICOS': 'biologicos.png',
+    'ALIMENTO PERROS Y GATOS': 'alimento_perros_gatos.png',
+    'PESTICIDAS': 'pesticidas.png',
+    'ASPERSORAS': 'aspersoras.png',
+    'REFACCIONES': 'refacciones.png',
+    'MASCOTAS': 'mascotas.png',
+    'SALES MINERALES': 'sales_minerales.png',
+    'FERRETERÍA': 'ferreteria.png',
+    'SEMILLAS': 'semillas.png',
+    'FERTILIZANTES': 'fertilizantes.png',
+    'FUNGICIDAS': 'fungicidas.png',
+    'HERBICIDAS': 'herbicidas.png',
+    'COADYUVANTE': 'coadyuvante.png',
+    'IMPLEMENTOS': 'implementos.png',
+    'INSTRUMENTAL': 'instrumental.png',
+    'TALABARTERÍA': 'talabarteria.png',
+    'MAQUINARIA': 'maquinaria.png',
+    'ALIMENTOS BALANCEADOS': 'alimentos_balanceados.png',
+    'FORRAJES': 'forrajes.png',
+    'RATICIDA': 'raticida.png',
+    'SERVICIOS': 'servicios.png'
+  };
 
   // Función para formatear cada palabra con inicial mayúscula
   function formatLabel(str) {
@@ -99,8 +127,15 @@ document.addEventListener('DOMContentLoaded', () => {
     categoriesList.forEach(cat => {
       const card = document.createElement('div');
       card.className = 'card category-card';
+      // imagen de categoría
+      const img = document.createElement('img');
+      img.src = `/images/categories/${categoryImages[cat] || 'default.png'}`;
+      img.alt = formatLabel(cat);
+      card.appendChild(img);
       const label = formatLabel(cat);
-      card.innerHTML = `<h3>${label}</h3>`;
+      const title = document.createElement('h3');
+      title.textContent = label;
+      card.appendChild(title);
       const link = document.createElement('a');
       link.href = `lista.html?categoria=${encodeURIComponent(cat)}`;
       link.appendChild(card);

--- a/public/styles.css
+++ b/public/styles.css
@@ -188,6 +188,13 @@ body {
     display: block;     /* elimina espacios en línea */
 }
 
+.category-card img {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+    border-bottom: 1px solid #ddd;
+}
+
 .card h3 {
     margin: 1rem 0;
 }


### PR DESCRIPTION
## Summary
- simplify header navigation
- add category image mapping and show images in category cards
- style category card images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a71259c688327a9bd9467e8c8589e