### PR TITLE
Add header logo size variable

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -8,6 +8,7 @@
     --gray-dark: #333333;
     --transition: 0.3s ease;
     --font-base: -apple-system, sans-serif;
+    --header-logo-size: 40px; /* Ajusta aqui el tamaño del logo en el encabezado */
     font-family: var(--font-base);
 }
 
@@ -40,7 +41,7 @@ body {
 }
 
 .logo-header {
-    width: 40px;
+    width: var(--header-logo-size);
     height: auto;
     vertical-align: middle;
     margin-right: 0.5rem;


### PR DESCRIPTION
## Summary
- allow custom header logo size by using a CSS variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a944aeb588327b8573e6da0255838