### PR TITLE
Enable list and adjustable grid views

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,10 @@
     </section>
 
     <section class="categorias reveal visible">
+        <div class="controles">
+            <button id="vista-grid" class="activo">Cuadrícula</button>
+            <button id="vista-lista">Lista</button>
+        </div>
         <div id="categories-container" class="grid"></div>
     </section>
 

--- a/public/lista.html
+++ b/public/lista.html
@@ -46,6 +46,10 @@
         <option value="Fluralaner">Fluralaner</option>
         <option value="Ivermectina">Ivermectina</option>
     </select>
+    <div class="controles">
+        <button id="vista-grid" class="activo">Cuadrícula</button>
+        <button id="vista-lista">Lista</button>
+    </div>
     <div id="lista-container" class="grid"></div>
     <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -143,9 +143,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (document.getElementById('categories-container')) {
+  const contCategorias = document.getElementById('categories-container');
+  if (contCategorias) {
     renderCategories();
-    return; // saltar lógica de productos
   }
 
   // Contenedores de productos
@@ -159,6 +159,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const categoriaSelect = document.getElementById('categoriaSelect');
   const productForm = document.getElementById('product-form');
   let productos = [];
+  let gridCols = 2;
+
+  function gridContainers() {
+    return [contCategorias, contVet, contAgr, contLista].filter(Boolean);
+  }
+
+  function setGridCols(cols) {
+    gridCols = cols;
+    gridContainers().forEach(c => {
+      if (!c.classList.contains('lista')) {
+        c.style.setProperty('--grid-cols', cols);
+      }
+    });
+  }
+
+  setGridCols(gridCols);
 
   const params = new URLSearchParams(window.location.search);
   const catParam = params.get('categoria') || '';
@@ -291,7 +307,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  fetchProductos();
+  if (contLista || contVet || contAgr || contProductos || adminTable) {
+    fetchProductos();
+  }
 
   // Escucha mensajes de otras pestañas con precios actualizados
   bc.onmessage = e => {
@@ -306,19 +324,24 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function toggleVista(lista) {
-    if (contVet || contAgr) {
-      contVet && contVet.classList.toggle('lista', lista);
-      contAgr && contAgr.classList.toggle('lista', lista);
-    } else if (contLista) {
-      contLista.classList.toggle('lista', lista);
-    }
+    gridContainers().forEach(c => c.classList.toggle('lista', lista));
+    if (!lista) setGridCols(gridCols);
     if (vistaGridBtn && vistaListaBtn) {
       vistaGridBtn.classList.toggle('activo', !lista);
       vistaListaBtn.classList.toggle('activo', lista);
     }
   }
 
-  if (vistaGridBtn) vistaGridBtn.addEventListener('click', () => toggleVista(false));
+  if (vistaGridBtn) {
+    vistaGridBtn.addEventListener('click', () => {
+      const anyLista = gridContainers().some(c => c.classList.contains('lista'));
+      if (anyLista) {
+        toggleVista(false);
+      } else {
+        setGridCols(gridCols === 2 ? 4 : 2);
+      }
+    });
+  }
   if (vistaListaBtn) vistaListaBtn.addEventListener('click', () => toggleVista(true));
 
   // Buscador y filtros en lista.html

--- a/public/styles.css
+++ b/public/styles.css
@@ -9,6 +9,7 @@
     --transition: 0.3s ease;
     --font-base: -apple-system, sans-serif;
     --header-height: 60px;
+    --grid-cols: 2;
     font-family: var(--font-base);
 }
 
@@ -162,9 +163,10 @@ body {
     color: #fff;
 }
 
+
 .grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(var(--grid-cols), 1fr);
     gap: 1.5rem;
     max-width: 1200px;
     margin: 0 auto;
@@ -172,7 +174,7 @@ body {
 
 /* Ajuste específico para las tarjetas de categorías */
 #categories-container {
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(var(--grid-cols), minmax(220px, 1fr));
     max-width: none;
 }
 


### PR DESCRIPTION
## Summary
- add global CSS variable for number of grid columns
- allow categories and products to toggle between grid/list views
- allow grid view to switch between 2 and 4 columns using the same button
- expose grid/list controls in `index.html` and `lista.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1c6974848327b5ea3469bd9db9bd