### PR TITLE
Enhance Excel import and admin controls

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -32,6 +32,10 @@
     <main class="productos reveal" style="padding-top: 100px;">
         <div class="controles">
             <input type="file" id="input-file" accept=".xlsx, .xls" />
+            <select id="excelOption">
+              <option value="combine">Combinar con existentes</option>
+              <option value="overwrite">Sobreescribir existentes</option>
+            </select>
             <button id="cargarExcel">Cargar precios desde Excel</button>
         </div>
 
@@ -54,15 +58,19 @@
         <table id="admin-table">
           <thead>
             <tr>
+              <th></th>
               <th>Nombre</th>
               <th>Precio</th>
               <th>Categoría</th>
               <th>Imagen</th>
-              <th>Acciones</th>
             </tr>
           </thead>
           <tbody></tbody>
         </table>
+        <div class="tabla-controles">
+          <button id="guardarTabla">Guardar cambios</button>
+          <button id="eliminarSeleccionados">Eliminar seleccionados</button>
+        </div>
       </main>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,16 @@ app.delete('/api/productos/:id', (req, res) => {
   });
 });
 
+// DELETE /api/productos
+app.delete('/api/productos', (req, res) => {
+  const db = new sqlite3.Database(path.join(__dirname, 'db.sqlite'));
+  db.run('DELETE FROM productos', [], function (err) {
+    db.close();
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ changes: this.changes });
+  });
+});
+
 // GET /api/exportar
 app.get('/api/exportar', async (req, res) => {
   const db = new sqlite3.Database(path.join(__dirname, 'db.sqlite'));


### PR DESCRIPTION
## Summary
- add import option to combine or overwrite when uploading Excel
- remove "AVES DE CORRAL" category from categories list
- move save/delete controls to whole table with checkboxes
- enable bulk save and delete actions
- add API route to delete all products

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b2dc2371083279af331a44288da83