### PR TITLE
Add deduplication to Excel imports

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -33,7 +33,8 @@
         <div class="controles">
             <input type="file" id="input-file" accept=".xlsx, .xls" />
             <select id="excelOption">
-              <option value="combine">Combinar con existentes</option>
+              <option value="clear">Importar y eliminar todo lo demás</option>
+              <option value="combine">Importar y combinar</option>
               <option value="overwrite">Sobreescribir existentes</option>
             </select>
             <button id="cargarExcel">Cargar precios desde Excel</button>


### PR DESCRIPTION
## Summary
- update admin import options
- implement deduplicated Excel import logic

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_684b31a43e08832782f247b662f6f93a