### PR TITLE
Fix underline on category titles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -178,6 +178,13 @@ body {
     max-width: none;
     max-height: fit-content;
 }
+#categories-container a {
+    text-decoration: none;
+    color: inherit;
+}
+#categories-container a:hover {
+    text-decoration: none;
+}
 
 .grid.lista {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- remove default underline styling for category cards

## Testing
- `npm test` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68509a6e95488327a1a389020b19ccb6