### PR TITLE
Fix pages workflow permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant required id-token permissions for deploy-pages workflow

## Testing
- `npm test` (root - fails: missing script)
- `npm test` in server directory

------
https://chatgpt.com/codex/tasks/task_e_6851e340520083278ba956fcff500a58